### PR TITLE
fix swagger version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Digipolis Swagger library
 
+## 1.0.4
+
+- Set swagger definition to Swagger v2 in stead of OpenApi v3, openapi-validator.antwerpen.be only supports up to v2
+
 ## 1.0.2 - 1.0.3
 
 - Added code to create the AddPublishJsonButton.js file on startup from embedded resource

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ To add the library to a project, you add the package to the csproj file :
 
 ```xml
   <ItemGroup>
-    <PackageReference Include="Digipolis.swagger" Version="1.0.0" />
+    <PackageReference Include="Digipolis.swagger" Version="1.0.4" />
   </ItemGroup>
 ```
 

--- a/src/Digipolis.swagger/Digipolis.swagger.csproj
+++ b/src/Digipolis.swagger/Digipolis.swagger.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <TargetFramework>netstandard2.1</TargetFramework>
-        <Version>1.0.3</Version>
+        <Version>1.0.4</Version>
     </PropertyGroup>
 
     <ItemGroup>

--- a/src/Digipolis.swagger/Startup/ApplicationBuilderExtensions.cs
+++ b/src/Digipolis.swagger/Startup/ApplicationBuilderExtensions.cs
@@ -21,6 +21,7 @@ namespace Digipolis.Swagger.Startup
                 {
                     swaggerDoc.Servers = new List<OpenApiServer>() { new OpenApiServer() { Url = $"{httpReq.Scheme}://{httpReq.Host.Value}" } };
                 });
+                options.SerializeAsV2 = true;
             });
 
             app.UseSwaggerUI(options =>


### PR DESCRIPTION
openapi-validator.antwerpen.be only supports swagger files up to version Swagger v2, the toolbox generates OpenApi v3 swagger files. 
Fixes the swagger version.
Resolves digipolisantwerpen/swagger_aspnetcore#6