### PR TITLE
Feature/thread safe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Digipolis Swagger library
 
+## 1.0.7
+
+- Added lock when creating the directory and file to assure thread safety
+
 ## 1.0.6
 
 - set correct path to include xml-comments

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ To add the library to a project, you add the package to the csproj file :
 
 ```xml
   <ItemGroup>
-    <PackageReference Include="Digipolis.swagger" Version="1.0.6" />
+    <PackageReference Include="Digipolis.swagger" Version="1.0.7" />
   </ItemGroup>
 ```
 

--- a/src/Digipolis.swagger/Digipolis.swagger.csproj
+++ b/src/Digipolis.swagger/Digipolis.swagger.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <TargetFramework>netstandard2.1</TargetFramework>
-        <Version>1.0.6</Version>
+        <Version>1.0.7</Version>
     </PropertyGroup>
 
     <ItemGroup>

--- a/src/Digipolis.swagger/Startup/ApplicationBuilderExtensions.cs
+++ b/src/Digipolis.swagger/Startup/ApplicationBuilderExtensions.cs
@@ -57,6 +57,7 @@ namespace Digipolis.Swagger.Startup
             return app;
         }
 
+        private static readonly object resourceLock = new object();
         private static void CreateResource(string outputDir)
         {
             // Get the name of the toolbox assembly
@@ -67,16 +68,20 @@ namespace Digipolis.Swagger.Startup
             // Read the embedded resource as a stream
             using var stream = assembly.GetManifestResourceStream(resource);
             if (stream == null) return;
-            // Ensure the directory exists
-            if (!Directory.Exists(outputDir))
+            
+            lock (resourceLock) 
             {
-                Directory.CreateDirectory(outputDir);
-            }
-            // Create/open the file for writing
-            using (var file = File.Create(Path.Combine(outputDir, _fileName)))
-            {
-                // Copy the contents of the embedded resource into the file
-                stream.CopyToAsync(file);
+                // Ensure the directory exists
+                if (!Directory.Exists(outputDir))
+                {
+                    Directory.CreateDirectory(outputDir);
+                }
+                // Create/open the file for writing
+                using (var file = File.Create(Path.Combine(outputDir, _fileName)))
+                {
+                    // Copy the contents of the embedded resource into the file
+                    stream.CopyToAsync(file);
+                }
             }
         }
     }


### PR DESCRIPTION
Add lock when creating directory and files to ensure thread safety.
Helpfull when working with multiple integration tests f.e.